### PR TITLE
Replace sidebar with always-visible navbar

### DIFF
--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -273,27 +273,31 @@ p {
   line-height: 26px;
 }
 
-.content {
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-}
-
-.sidebar {
+.navbar {
   width: 100%;
-  height: 100%;
-  max-width: 280px;
   background-color: #1c1c1c;
-  border-right: 1px solid #353535;
-  padding: 32px;
+  border-bottom: 1px solid #353535;
+  padding: 18px 32px;
 }
 
 .nav-content {
   width: 100%;
-  height: 100%;
-  grid-column-gap: 36px;
-  grid-row-gap: 36px;
-  flex-direction: column;
+  grid-column-gap: 24px;
+  grid-row-gap: 24px;
+  justify-content: space-between;
+  align-items: center;
+  display: flex;
+}
+
+.nav-brand {
+  text-decoration: none;
+}
+
+.nav-links {
+  grid-column-gap: 12px;
+  grid-row-gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
   display: flex;
 }
 
@@ -558,52 +562,24 @@ p {
 }
 
 @media screen and (max-width: 991px) {
-  .content {
-    flex-direction: column;
-  }
-
-  .sidebar {
-    height: auto;
-    max-width: 100%;
-    padding-top: 18px;
-    padding-bottom: 18px;
-    padding-right: 28px;
+  .navbar {
+    padding-left: 24px;
+    padding-right: 24px;
   }
 
   .nav-content {
-    height: auto;
-    grid-column-gap: 0px;
-    grid-row-gap: 0px;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
+    grid-column-gap: 12px;
+    grid-row-gap: 12px;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .nav-links {
+    width: 100%;
   }
 
   .fold-content {
     margin-bottom: 32px;
-  }
-
-  .nav-link-container {
-    background-color: #1c1c1c;
-    border-radius: 0;
-    padding: 18px 28px 18px 32px;
-  }
-
-  .nav-link-container:active {
-    color: #fff;
-    background-color: #2b2b2b;
-  }
-
-  .navbar-icon {
-    width: 32px;
-    height: 32px;
-    color: #fff;
-    font-size: 32px;
-  }
-
-  .navbar-icon-button {
-    padding: 12px;
-    transition: all 0.24s;
   }
 }
 
@@ -617,11 +593,6 @@ p {
     font-size: 32px;
     font-weight: 300;
     line-height: 48px;
-  }
-
-  .sidebar {
-    padding-left: 24px;
-    padding-right: 18px;
   }
 
   .main {

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -2,17 +2,9 @@
 const { selectedItem } = Astro.props;
 ---
 
-<aside
-  data-animation="default"
-  data-collapse="medium"
-  data-duration="400"
-  data-easing="ease"
-  data-easing2="ease"
-  role="banner"
-  class="sidebar w-nav"
->
+<nav class="navbar">
   <div class="nav-content">
-    <a href="/" class="w-nav-brand" aria-label="home">
+    <a href="/" class="nav-brand" aria-label="home">
       <div class="niv-data">
         <img
           src="/assets/sam.jpg"
@@ -27,7 +19,7 @@ const { selectedItem } = Astro.props;
       </div>
     </a>
 
-    <nav role="navigation" class="w-nav-menu">
+    <div class="nav-links">
       <a
         href="/"
         class={`nav-link-container w-inline-block ${
@@ -87,35 +79,6 @@ const { selectedItem } = Astro.props;
         />
         <div>Contacto</div>
       </a>
-    </nav>
-
-    <div
-      class="navbar-icon-button w-nav-button"
-      style="-webkit-user-select: text;"
-      aria-label="menu"
-      role="button"
-      tabindex="0"
-    >
-      <img
-        src="/assets/menu.svg"
-        loading="eager"
-        alt=""
-        class="navbar-icon"
-      />
     </div>
   </div>
-
-  <script>
-    import { setupNav } from '../scripts/nav.js';
-
-    let cleanup;
-    document.addEventListener('astro:page-load', () => {
-      if (cleanup) cleanup();
-      cleanup = setupNav();
-    });
-
-    document.addEventListener('astro:before-swap', () => {
-      if (cleanup) cleanup();
-    });
-  </script>
-</aside>
+</nav>

--- a/src/pages/caso-de-exito.astro
+++ b/src/pages/caso-de-exito.astro
@@ -1,5 +1,6 @@
 ---
 import Header from "../components/Header.astro";
+import Navbar from "../components/Navbar.astro";
 import Project from "../components/Project.astro";
 const project = {
   title: "CodeCraft",
@@ -17,27 +18,25 @@ const project = {
 <html>
   <Header title="Caso de éxito | Sam Bernstein" />
   <body>
-    <div class="content">
-      <Sidebar selectedItem="casos" />
-      <nav class="main">
-        <div class="container">
-          <div class="back-nav-container">
-            <a href="/casos" class="back-nav-button w-inline-block"
-              ><img src="/assets/back.svg" loading="lazy" alt="" class="back-nav-img" />
-              <div>Volver</div></a
-            >
-          </div>
-          <div class="content-container">
-            <h1>Caso de éxito</h1>
-            <section class="items-container">
-              <div class="resouce-items">
-                <Project title={project.title} desc={project.desc} tech={project.tech} />
-              </div>
-            </section>
-          </div>
+    <Navbar selectedItem="casos" />
+    <nav class="main">
+      <div class="container">
+        <div class="back-nav-container">
+          <a href="/casos" class="back-nav-button w-inline-block"
+            ><img src="/assets/back.svg" loading="lazy" alt="" class="back-nav-img" />
+            <div>Volver</div></a
+          >
         </div>
-      </nav>
-    </div>
+        <div class="content-container">
+          <h1>Caso de éxito</h1>
+          <section class="items-container">
+            <div class="resouce-items">
+              <Project title={project.title} desc={project.desc} tech={project.tech} />
+            </div>
+          </section>
+        </div>
+      </div>
+    </nav>
 
     <!--[if lte IE 9]><script src="//cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js"></script><![endif]-->
   </body>


### PR DESCRIPTION
## Summary
- replace the sidebar component with a horizontal navbar that is always shown
- update the case detail page to use the new navbar and remove the sidebar layout
- adjust global styles for the navbar and clean up unused sidebar rules

## Testing
- not run (npm install repeatedly hung and was terminated)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928818c5c648322811da80be1bf2b76)