### PR TITLE
Add detailed case details to case pages

### DIFF
--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -442,6 +442,48 @@ p {
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
 }
 
+.case-detail {
+  margin-top: 48px;
+  grid-row-gap: 24px;
+  flex-direction: column;
+  display: flex;
+}
+
+.case-detail-section {
+  background-color: rgba(28, 28, 28, 0.32);
+  border: 1px solid #353535;
+  border-radius: 12px;
+  padding: 20px 24px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+}
+
+.case-detail-section h3 {
+  color: #fff;
+  margin-top: 0;
+}
+
+.case-detail-section p {
+  color: #dcdcdc;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.case-quote {
+  border-left: 3px solid #f5546f;
+}
+
+.case-quote-text {
+  color: #fff;
+  font-size: 18px;
+  line-height: 26px;
+  margin-bottom: 8px;
+}
+
+.case-quote-author {
+  color: #a8a8a8;
+  margin-bottom: 0;
+}
+
 .resouce-items {
   grid-column-gap: 64px;
   grid-row-gap: 64px;

--- a/src/content/casos/chipicasa.md
+++ b/src/content/casos/chipicasa.md
@@ -15,4 +15,12 @@ tech:
   - "Custom theme"
   - "XML portal feeds"
 image: "/assets/casos/chipicasa.png"
+companySector: "Chipicasa — Agencia inmobiliaria en Chipiona."
+problem: "La agencia necesitaba un sistema centralizado para gestionar propiedades, leads y propietarios, además de publicar en portales externos sin duplicar trabajo. Las herramientas habituales no cubrían su operativa ni ofrecían un CRM adaptado a su negocio."
+solution: "Se desarrolló un CRM completo dentro de WordPress mediante plugins a medida y un theme propio basado en _underscores. Incluye gestión de inmuebles, propietarios y demandantes con ficha y estudios propios, control de citas, seguimiento de leads, gráficas y envío de correos automáticos. Además, se implementó la sincronización automática con Idealista, Fotocasa y Pisos.com, manteniendo precios y disponibilidad siempre actualizados."
+result: "Chipicasa pasó de una web básica a un CRM inmobiliario operativo sobre WordPress. Ahora gestiona todo su flujo comercial —propiedades, clientes y publicaciones en portales— desde una sola plataforma, reduciendo horas de trabajo manual y aumentando la profesionalidad del equipo."
+quote:
+  text: "Ahora gestionamos toda la agencia desde nuestra web: propiedades, clientes y publicaciones en los portales inmobiliarios. Es como tener un CRM hecho a medida, pero dentro de WordPress."
+  author: "Jeremy Scharberg, Gerente de Chipicasa"
+contribution: "Arquitectura del sistema, desarrollo de plugins, creación del theme, integraciones con portales y mantenimiento en VPS."
 ---

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -7,7 +7,18 @@ const casosCollection = defineCollection({
     link: z.string().url().optional(),
     desc: z.array(z.string()),
     tech: z.array(z.string()),
-    image: z.string().optional()
+    image: z.string().optional(),
+    companySector: z.string().optional(),
+    problem: z.string().optional(),
+    solution: z.string().optional(),
+    result: z.string().optional(),
+    quote: z
+      .object({
+        text: z.string(),
+        author: z.string()
+      })
+      .optional(),
+    contribution: z.string().optional()
   })
 });
 

--- a/src/pages/casos/[slug].astro
+++ b/src/pages/casos/[slug].astro
@@ -51,6 +51,61 @@ const project = caso.data;
               )}
             </section>
 
+            <section class="case-detail">
+              {project.companySector && (
+                <div class="case-detail-section">
+                  <div class="mini-label-white gray-color">Empresa / Sector</div>
+                  <p>{project.companySector}</p>
+                </div>
+              )}
+
+              {project.problem && (
+                <div class="case-detail-section">
+                  <h3>El problema</h3>
+                  <p>{project.problem}</p>
+                </div>
+              )}
+
+              {project.solution && (
+                <div class="case-detail-section">
+                  <h3>La solución</h3>
+                  <p>{project.solution}</p>
+                </div>
+              )}
+
+              {project.result && (
+                <div class="case-detail-section">
+                  <h3>Resultado</h3>
+                  <p>{project.result}</p>
+                </div>
+              )}
+
+              {project.quote && (
+                <div class="case-detail-section case-quote">
+                  <p class="case-quote-text">“{project.quote.text}”</p>
+                  <p class="case-quote-author">— {project.quote.author}</p>
+                </div>
+              )}
+
+              {project.contribution && (
+                <div class="case-detail-section">
+                  <h3>Mi aporte</h3>
+                  <p>{project.contribution}</p>
+                </div>
+              )}
+
+              {project.tech?.length > 0 && (
+                <div class="case-detail-section">
+                  <h3>Tecnologías</h3>
+                  <div class="chips-container">
+                    {project.tech.map(techItem => (
+                      <div class="single-chip">{techItem}</div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </section>
+
           </div>
 
         </div>


### PR DESCRIPTION
## Summary
- extend the casos collection schema with optional detailed fields for problem, solution, results, and testimonials
- add Chipicasa case content for the new sections and render them on the case detail page
- style the new case detail sections to match the rest of the site

## Testing
- npm run build *(fails: astro command not available in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929bb2552c08322b5598836380b13c6)