### PR TITLE
Update marketing content across Astro pages

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -28,25 +28,42 @@ const { selectedItem } = Astro.props;
     </a>
 
     <nav role="navigation" class="w-nav-menu">
-      <a
-        href="/"
-        class={`nav-link-container w-inline-block ${
-          selectedItem === 'home' ? 'w--current' : ''
-        }`}
-      >
-        <img
-          src="/assets/home.svg"
-          loading="eager"
-          alt=""
-          class="nav-link-image"
-        />
-        <div>Home</div>
-      </a>
-      <a
-        href="/casos"
-        class={`nav-link-container w-inline-block ${
-          selectedItem === 'casos' ? 'w--current' : ''
-        }`}
+        <a
+          href="/"
+          class={`nav-link-container w-inline-block ${
+            selectedItem === 'home' ? 'w--current' : ''
+          }`}
+        >
+          <img
+            src="/assets/home.svg"
+            loading="eager"
+            alt=""
+            class="nav-link-image"
+          />
+          <div>Home</div>
+        </a>
+        <a
+          href="/servicios"
+          class={`nav-link-container w-inline-block ${
+            selectedItem === 'servicios' ? 'w--current' : ''
+          }`}
+          aria-current={
+            selectedItem === 'servicios' ? 'page' : undefined
+          }
+        >
+          <img
+            src="/assets/browser.svg"
+            loading="eager"
+            alt=""
+            class="nav-link-image"
+          />
+          <div>Servicios</div>
+        </a>
+        <a
+          href="/casos"
+          class={`nav-link-container w-inline-block ${
+            selectedItem === 'casos' ? 'w--current' : ''
+          }`}
         aria-current={
           selectedItem === 'casos' ? 'page' : undefined
         }

--- a/src/pages/casos.astro
+++ b/src/pages/casos.astro
@@ -22,11 +22,16 @@ const casos = (await getCollection("casos")).sort((a, b) => a.data.order - b.dat
             </a>
           </div>
 
-          <div class="content-container">
-            <h1>Casos de éxito</h1>
+            <div class="content-container">
+              <h1>Casos de éxito</h1>
+              <p class="lead">
+                Aquí encontrarás proyectos reales en los que he trabajado: ampliaciones, integraciones, automatizaciones y mejoras técnicas desarrolladas sobre WordPress.
+                Cada caso detalla el problema, la solución aplicada y los resultados obtenidos.
+                Los testimonios asociados aparecen dentro del detalle de cada caso.
+              </p>
 
-            <section class="items-container">
-              <div class="resouce-items">
+              <section class="items-container">
+                <div class="resouce-items">
                 {casos.map(({ slug, data }) => (
                   <a href={`/casos/${slug}`} class="project-link">
                     <Project

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -5,7 +5,7 @@ import Sidebar from '../components/Sidebar.astro';
 
 <!DOCTYPE html>
 <html>
-  <Header title="Contacto | Sam Bernstein" />
+  <Header title="Contacto | JJ Montalban" />
   <body>
     <div class="content">
       <Sidebar selectedItem="contacto" />
@@ -14,13 +14,14 @@ import Sidebar from '../components/Sidebar.astro';
           <div class="back-nav-container">
             <a href="/" class="back-nav-button w-inline-block"
               ><img src="/assets/back.svg" loading="lazy" alt="" class="back-nav-img" />
-              <div>Back</div></a
+              <div>Volver</div></a
             >
           </div>
           <div class="content-container">
             <h1>Contacto</h1>
             <p class="lead">
-              ¿Tienes un proyecto o idea en mente? Completa el formulario para compartir los detalles y me pondré en contacto contigo.
+              Cuéntame qué necesitas mejorar en tu WordPress y te responderé con una propuesta clara y adaptada a tu situación real.
+              Trabajo con proyectos nuevos y con sitios ya existentes que requieren mejoras, estabilización o funcionalidades avanzadas.
             </p>
             <section class="items-container">
               <div class="contact-card">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,90 +1,102 @@
 ---
 import Header from "../components/Header.astro";
-import Footer from "../components/Footer.astro";
-import "../styles/global.css";
 ---
 
 <Header />
 
 <main id="content">
+  <!-- Intro -->
+  <section id="short" class="section-fade is-visible">
+    <div class="intro-wrapper">
+      <h1 class="intro-text">Desarrollo WordPress especializado para mejorar lo que ya tienes.</h1>
 
-    <!-- Intro -->
-    <section id="short" class="section-fade is-visible">
-        <div class="intro-wrapper">
-            <h1 class="intro-text">Hola, soy JJ</h1>
+      <h2 class="intro-subtext">
+        Funcionalidades a medida, rendimiento, seguridad e integraciones sin necesidad de rehacer tu web desde cero.
+      </h2>
 
-            <h2 class="intro-subtext">
-                Desarrollo de aplicaciones web con WordPress
-            </h2>
+      <a class="link-button work-button" href="/contacto">Hablemos de tu proyecto</a>
+    </div>
+  </section>
 
-            <p class="intro-paragraph">
-                Plugins personalizados, integraciones complejas y soluciones avanzadas para empresas que necesitan más que una web.
-            </p>
-
-            <p class="intro-paragraph">
-                Transformo WordPress en herramientas de negocio con soluciones a medida:
-                CRMs, sistemas de gestión integrados, reservas y más. Revisa algunos
-                <a class="link-button work-button" href="/casos">casos de éxito</a>.
-            </p>
-
-            <p class="intro-paragraph">
-                Además de proyectos para clientes, contribuyo activamente al ecosistema WordPress con
-                <a class="link-button contributions-button" href="/plugins">plugins publicados</a>
-                en el repositorio oficial y proyectos personales.
-            </p>
-        </div>
-    </section>
-
-    <!-- Contacto -->
-    <section id="contact" class="section-fade is-visible">
-
-        <p class="contact-text">
-            Pincha en los links para encontrarme o envíame un email:
-            <a href="mailto:jjmontalban@gmail.com">click</a>
+  <!-- Servicios principales -->
+  <section class="section-fade is-visible">
+    <div class="intro-wrapper">
+      <h2 class="intro-subtext">Servicios principales</h2>
+      <div class="intro-paragraph">
+        <h3>Plugins WordPress a medida</h3>
+        <p>
+          Diseño e implemento funcionalidades específicas que complementan tu WordPress actual sin sustituir tu tema ni tus plugins.
+          Código limpio, mantenible y alineado con las buenas prácticas del ecosistema WordPress.
         </p>
+      </div>
+      <div class="intro-paragraph">
+        <h3>Mejoras sobre tu WordPress actual</h3>
+        <p>
+          No necesitas reconstruir tu sitio. Puedo adaptar y ampliar lo que ya tienes para que tu negocio pueda crecer sin fricciones técnicas.
+        </p>
+      </div>
+      <div class="intro-paragraph">
+        <h3>Integraciones y automatización</h3>
+        <p>
+          Conexiones con APIs externas, CRMs, plataformas inmobiliarias como Pisos.com, sincronización de datos y automatización de procesos.
+        </p>
+      </div>
+      <div class="intro-paragraph">
+        <h3>Rendimiento y seguridad</h3>
+        <p>
+          Optimización WPO, estabilización técnica, configuraciones CSP, mitigación de vulnerabilidades y mejoras orientadas a la fiabilidad.
+        </p>
+      </div>
+    </div>
+  </section>
 
-        <nav class="social-nav">
-            <ul>
-                <li>
-                    <a href="https://github.com/jjmontalban" target="_blank" title="Github">
-                        <i class="fab fa-github"></i>
-                    </a>
-                </li>
+  <!-- Sobre mí -->
+  <section class="section-fade is-visible">
+    <div class="intro-wrapper">
+      <h2 class="intro-subtext">Por qué trabajar conmigo</h2>
+      <p class="intro-paragraph">
+        Soy un desarrollador WordPress freelance con experiencia en proyectos corporativos, integraciones complejas y portales con necesidades técnicas avanzadas.
+      </p>
+      <p class="intro-paragraph">
+        Trabajo de forma incremental: mejoro tu plataforma actual sin obligarte a rehacerla desde cero.
+      </p>
+      <p class="intro-paragraph">
+        Mi enfoque combina desarrollo a medida, rendimiento, seguridad y escalabilidad.
+      </p>
+      <p class="intro-paragraph">
+        Comunicación directa, entregas rápidas y soluciones pensadas para durar.
+      </p>
+    </div>
+  </section>
 
-                <li>
-                    <a href="https://profiles.wordpress.org/jjmontalban/" target="_blank" title="WordPress">
-                        <i class="fa-brands fa-wordpress"></i>
-                    </a>
-                </li>
+  <!-- Plugins destacados -->
+  <section class="section-fade is-visible">
+    <div class="intro-wrapper">
+      <h2 class="intro-subtext">Plugins destacados</h2>
+      <p class="intro-paragraph">
+        He publicado diversos plugins que aportan soluciones reales a problemas habituales de WordPress.
+        Son una muestra de mi enfoque en estabilidad, rendimiento y control.
+        Puedes ver el listado completo en <a class="link-button contributions-button" href="/plugins">/plugins</a>.
+      </p>
+    </div>
+  </section>
 
-                <li>
-                    <a href="https://www.behance.net/jjmontalban" target="_blank" title="Behance">
-                        <i class="fab fa-behance"></i>
-                    </a>
-                </li>
+  <!-- Casos de éxito -->
+  <section class="section-fade is-visible">
+    <div class="intro-wrapper">
+      <h2 class="intro-subtext">Casos de éxito</h2>
+      <p class="intro-paragraph">
+        He trabajado en integraciones técnicas, portales corporativos y desarrollos especializados para WordPress.
+        Puedes ver resultados reales aquí: <a class="link-button work-button" href="/casos">/casos</a>.
+      </p>
+    </div>
+  </section>
 
-                <li>
-                    <a href="https://www.linkedin.com/in/jjmontalban/" target="_blank" title="LinkedIn">
-                        <i class="fab fa-linkedin"></i>
-                    </a>
-                </li>
-
-                <li>
-                    <a href="https://unsplash.com/@jjmontalban" target="_blank" title="Unsplash">
-                        <i class="fa-brands fa-unsplash"></i>
-                    </a>
-                </li>
-
-                <li>
-                    <a href="https://www.chess.com/member/jjmontalban" target="_blank" title="Chess">
-                        <i class="fas fa-chess-king"></i>
-                    </a>
-                </li>
-            </ul>
-        </nav>
-
-    </section>
-
+  <!-- CTA final -->
+  <section id="contact" class="section-fade is-visible">
+    <div class="intro-wrapper">
+      <p class="intro-paragraph">¿Quieres mejorar tu WordPress sin rehacerlo desde cero?</p>
+      <a class="link-button work-button" href="/contacto">Hablemos</a>
+    </div>
+  </section>
 </main>
-
-<Footer />

--- a/src/pages/plugins.astro
+++ b/src/pages/plugins.astro
@@ -62,6 +62,11 @@ const personalProject = {
           </div>
           <div class="content-container">
             <h1>Plugins publicados en WordPress.org</h1>
+            <p class="lead">
+              Esta sección reúne mis plugins publicados y herramientas que he creado para resolver problemas reales en WordPress.
+              Muchos de ellos nacieron de necesidades concretas de clientes y ahora aportan valor a más usuarios.
+              Puedes ver el código, instalarlos o utilizarlos como referencia para desarrollos a medida.
+            </p>
             <section class="items-container">
               <div class="resouce-items">
                 {plugins.map(plugin => (

--- a/src/pages/servicios.astro
+++ b/src/pages/servicios.astro
@@ -1,0 +1,103 @@
+---
+import Header from "../components/Header.astro";
+import Sidebar from "../components/Sidebar.astro";
+---
+
+<!DOCTYPE html>
+<html>
+  <Header title="Servicios | JJ Montalban" />
+  <body>
+    <div class="content">
+      <Sidebar selectedItem="servicios" />
+      <nav class="main">
+        <div class="container">
+          <div class="back-nav-container">
+            <a href="/" class="back-nav-button w-inline-block"
+              ><img src="/assets/back.svg" loading="lazy" alt="" class="back-nav-img" />
+              <div>Volver</div></a
+            >
+          </div>
+          <div class="content-container">
+            <h1>Servicios</h1>
+            <p class="lead">
+              Soluciones WordPress a medida diseñadas para mejorar tu plataforma actual sin necesidad de reconstruirla.
+              Trabajo sobre tu infraestructura real para crear un sistema más funcional, estable y preparado para crecer.
+            </p>
+
+            <section class="items-container">
+              <div class="resouce-items">
+                <article class="project-card">
+                  <h2>Plugins WordPress a medida</h2>
+                  <p>
+                    Desarrollo funcionalidades específicas totalmente integradas con tu WordPress.
+                    No necesitas cambiar de tema ni sustituir plugins clave: el desarrollo se adapta a tu sistema actual.
+                  </p>
+                  <h3>Incluye:</h3>
+                  <ul>
+                    <li>Campos personalizados y flujos específicos</li>
+                    <li>Módulos y bloques ACF personalizados</li>
+                    <li>Integración con el editor</li>
+                    <li>Controles avanzados para administradores</li>
+                    <li>Funcionalidades internas y automatización de procesos</li>
+                  </ul>
+                </article>
+
+                <article class="project-card">
+                  <h2>Mejoras sobre WordPress existente</h2>
+                  <p>
+                    Tu sitio no necesita empezar de cero.
+                    Puedo ampliar, mejorar o estabilizar lo que ya tienes manteniendo tu diseño, tu contenido y tu estructura actual.
+                  </p>
+                  <h3>Incluye:</h3>
+                  <ul>
+                    <li>Nuevas secciones o capacidades sobre tu tema actual</li>
+                    <li>Refactor técnico para evitar errores futuros</li>
+                    <li>Limpieza de código y optimización</li>
+                    <li>Ajustes orientados a escalabilidad y mantenimiento</li>
+                  </ul>
+                </article>
+
+                <article class="project-card">
+                  <h2>Integraciones y automatización</h2>
+                  <p>
+                    Conecto tu página con los servicios que necesita tu negocio.
+                    Automatizo tareas y sincronizo información para que tu WordPress trabaje por ti.
+                  </p>
+                  <h3>Incluye:</h3>
+                  <ul>
+                    <li>Integración con APIs externas</li>
+                    <li>Conexión con CRMs y plataformas inmobiliarias como Pisos.com</li>
+                    <li>Procesos automáticos de importación/exportación</li>
+                    <li>Automatización de emails, flujos y notificaciones</li>
+                  </ul>
+                </article>
+
+                <article class="project-card">
+                  <h2>Rendimiento y seguridad</h2>
+                  <p>
+                    Estabilizo tu sitio para que funcione rápido y sin incidencias.
+                    Me centro en rendimiento, seguridad y buenas prácticas.
+                  </p>
+                  <h3>Incluye:</h3>
+                  <ul>
+                    <li>Optimización WPO y mejora de tiempos de carga</li>
+                    <li>Configuración avanzada de CSP</li>
+                    <li>Mitigación de vulnerabilidades</li>
+                    <li>Auditorías técnicas y recomendaciones reales</li>
+                  </ul>
+                </article>
+              </div>
+            </section>
+
+            <section class="items-container">
+              <p class="lead">
+                ¿Quieres mejorar tu WordPress sin reconstruirlo entero?
+                <a class="link-button work-button" href="/contacto">Cuéntame qué necesitas</a>
+              </p>
+            </section>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Replace the home page with new WordPress-focused value proposition, services overview, and CTAs.
- Add a dedicated Servicios page and navigation link outlining key offerings and inclusions.
- Refresh introductory copy on Plugins, Casos de éxito, and Contacto pages to match the new positioning.

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c16615f488322902e9b46e721a519)